### PR TITLE
feat: add timseries functions

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -43,6 +43,31 @@ func TestParseDerived(t *testing.T) {
 			input:   `$foo AND AND($bar AND $baz, $quux)`,
 			wantErr: false,
 		},
+		{
+			name:    "timseries function",
+			input:   "MAX(LAST(1))",
+			wantErr: false,
+		},
+		{
+			name:    "nested timeseries function",
+			input:   "RATE(LAST(1))",
+			wantErr: true,
+			errMsg:  "timeseries operations cannot be nested",
+		},
+		{
+			// Not "nested" per se but we aren't allowed more than one TS op
+			// per expression.
+			name:    "multiple timeseries functions",
+			input:   "COALESCE(RATE(1),RATE(2))",
+			wantErr: true,
+			errMsg:  "timeseries operations cannot be nested",
+		},
+		{
+			name:    "unknown function",
+			input:   "DECREASE(1)",
+			wantErr: true,
+			errMsg:  "invalid function: DECREASE",
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -129,3 +129,34 @@ func lookupOp(str string) api.DeriveOp {
 		return api.DeriveOp_D_NONE
 	}
 }
+
+type TimeseriesOp int
+
+const (
+	TimeseriesOpNone TimeseriesOp = iota
+	TimeseriesOpRawMetric
+	TimeseriesOpLast
+	TimeseriesOpSummarize
+	TimeseriesOpIncrease
+	TimeseriesOpRate
+
+	TimeseriesOps_Len // I am a placeholder to allow for iterating over all ops
+	// DO NOT ADD ANY OPS BELOW THE PLACEHOLDER
+)
+
+func lookupTimeseriesOp(str string) TimeseriesOp {
+	switch str {
+	case "RAW_METRIC":
+		return TimeseriesOpRawMetric
+	case "LAST":
+		return TimeseriesOpLast
+	case "RATE":
+		return TimeseriesOpRate
+	case "INCREASE":
+		return TimeseriesOpIncrease
+	case "SUMMARIZE":
+		return TimeseriesOpSummarize
+	default:
+		return TimeseriesOpNone
+	}
+}


### PR DESCRIPTION
## Which problem is this PR solving?
We're now using the derived column language for intra-query expressions, including embedded timeseries expressions.

## Short description of the changes
This adds the existing timeseries expressions, following the rule that there can only be one in any given expression. Note this will allow operators like RATE in regular derived column definitions where it is NOT actually allowed by honeycomb's query engine.

## How to verify that this has the expected result
See new test cases.